### PR TITLE
Update AHT10 code to wait for busy mode before returning a value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,8 @@ where
         let buf: &mut [u8; 6] = &mut [0; 6];
         self.i2c.read(I2C_ADDRESS, buf)?;
 
-        let hum = ((buf[0] as u32) << 12) | ((buf[1] as u32) << 4) | ((buf[2] as u32) >> 4);
-        let temp = (((buf[2] as u32) & 0x0f) << 16) | ((buf[3] as u32) << 8) | (buf[4] as u32);
+        let hum = ((buf[1] as u32) << 12) | ((buf[2] as u32) << 4) | ((buf[3] as u32) >> 4);
+        let temp = (((buf[3] as u32) & 0x0f) << 16) | ((buf[4] as u32) << 8) | (buf[5] as u32);
         Ok((Humidity { h: hum }, Temperature { t: temp }))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ where
 
     // Read a value from the sensor as the 'current status'.
     fn read_status(&mut self) -> Result<StatusFlags, E> {
-        let buf: &mut [u8; 7] = &mut [0; 7];
+        let buf: &mut [u8; 1] = &mut [0; 1];
         self.i2c.read(I2C_ADDRESS, buf)?;
         let status = StatusFlags { bits: buf[0] };
         Ok(status)


### PR DESCRIPTION
I was testing AHT10 on my own device and I seem to always get uninitialized/uncalibrated values (looks like -50/50).

I believe it is because the device keeps returning a 'status' until the status of 'busy' is cleared. 
I looked what AdaFruit cpp was doing in its init:
  https://github.com/adafruit/Adafruit_AHTX0/blob/master/Adafruit_AHTX0.cpp#L90
as well as reads:
 https://github.com/adafruit/Adafruit_AHTX0/blob/master/Adafruit_AHTX0.cpp#L134

and it looks like the process is "keep reading until busy flag is cleared, then assume value is ok".

Changes:
   - updated the dependency of i2c to allow 'Read' 
   - added a method that just 'reads status' 
   - Added loops and adjusted timings (lower in general) to what adafruit seems to have used.
   
 Tested:
   - Tested on a CortexM0 and a AHT10. Without this change I get no valid values, with this change I seem to have valid results (temperature and humidity seem reasonable, if I place my finger on the sensor temp increases).